### PR TITLE
Add Vp9 encode functionality

### DIFF
--- a/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
@@ -15,6 +15,7 @@ import se.svt.oss.encore.model.output.Output
     JsonSubTypes.Type(value = AudioEncode::class, name = "AudioEncode"),
     JsonSubTypes.Type(value = X264Encode::class, name = "X264Encode"),
     JsonSubTypes.Type(value = X265Encode::class, name = "X265Encode"),
+    JsonSubTypes.Type(value = Vp9Encode::class, name = "Vp9Encode"),
     JsonSubTypes.Type(value = GenericVideoEncode::class, name = "VideoEncode"),
     JsonSubTypes.Type(value = ThumbnailEncode::class, name = "ThumbnailEncode"),
     JsonSubTypes.Type(value = ThumbnailMapEncode::class, name = "ThumbnailMapEncode")

--- a/src/main/kotlin/se/svt/oss/encore/model/profile/Vp9Encode.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/Vp9Encode.kt
@@ -1,0 +1,31 @@
+package se.svt.oss.encore.model.profile
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import se.svt.oss.encore.model.input.DEFAULT_VIDEO_LABEL
+
+data class Vp9Encode (
+    override val width: Int?,
+    override val height: Int?,
+    override val twoPass: Boolean,
+    @JsonProperty("params")
+    override val ffmpegParams: LinkedHashMap<String, String> = linkedMapOf(),
+    @JsonProperty("vp9-params")
+    override val codecParams: LinkedHashMap<String, String> = linkedMapOf(),
+    override val filters: List<String> = emptyList(),
+    override val audioEncode: AudioEncode? = null,
+    override val suffix: String,
+    override val format: String = "webm",
+    override val inputLabel: String = DEFAULT_VIDEO_LABEL
+) : VpXEncode() {
+    override val codecParamName: String
+        get() = "vp9-params"
+    override val codec: String
+        get() = "libvpx-vp9"
+
+    override fun passParams(pass: Int): Map<String, String> {
+        // codec args work differently with libvpx than than x26(4|5)
+        // we don't need to concat the codecparams into a single string here
+        val modifiedCodecParams = codecParams + mapOf("pass" to pass.toString(), "stats" to "log$suffix")
+        return modifiedCodecParams
+    }
+}

--- a/src/main/kotlin/se/svt/oss/encore/model/profile/Vp9Encode.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/Vp9Encode.kt
@@ -25,7 +25,7 @@ data class Vp9Encode (
     override fun passParams(pass: Int): Map<String, String> {
         // codec args work differently with libvpx than than x26(4|5)
         // we don't need to concat the codecparams into a single string here
-        val modifiedCodecParams = codecParams + mapOf("pass" to pass.toString(), "stats" to "log$suffix")
+        val modifiedCodecParams = codecParams + mapOf("pass" to pass.toString(), "passlogfile" to "log$suffix")
         return modifiedCodecParams
     }
 }

--- a/src/main/kotlin/se/svt/oss/encore/model/profile/VpXEncode.kt
+++ b/src/main/kotlin/se/svt/oss/encore/model/profile/VpXEncode.kt
@@ -1,0 +1,18 @@
+package se.svt.oss.encore.model.profile
+
+abstract class VpXEncode : VideoEncode {
+    abstract val ffmpegParams: LinkedHashMap<String, String>
+
+    abstract val codecParams: LinkedHashMap<String, String>
+    abstract val codecParamName: String
+
+    override val params: Map<String, String>
+        // codec parameters for libvpx are passed as normal ffmpeg arguments
+        // unlike x26(4|5), where it's one argument
+        // thus, we want really only need to concat the maps
+        get() = ffmpegParams + if(codecParams.isNotEmpty()) {
+            codecParams
+        } else {
+            emptyMap()
+        }
+}

--- a/src/test/kotlin/se/svt/oss/encore/model/profile/Vp9EncodeTest.kt
+++ b/src/test/kotlin/se/svt/oss/encore/model/profile/Vp9EncodeTest.kt
@@ -1,0 +1,51 @@
+package se.svt.oss.encore.model.profile
+
+import se.svt.oss.encore.Assertions.assertThat
+
+class Vp9EncodeTest : VideoEncodeTest<Vp9Encode>() {
+    override fun createEncode(
+        width: Int?,
+        height: Int?,
+        twoPass: Boolean,
+        params: LinkedHashMap<String, String>,
+        filters: List<String>,
+        audioEncode: AudioEncode?
+    ): Vp9Encode = Vp9Encode(
+        width = width,
+        height = height,
+        twoPass = twoPass,
+        ffmpegParams = params,
+        codecParams = linkedMapOf("c" to "d"),
+        filters = filters,
+        audioEncode = audioEncode,
+        suffix = "-vp9"
+    )
+
+    override fun verifyFirstPassParams(encode: VideoEncode, params: List<String>) {
+        if (encode.twoPass) {
+            assertThat(params)
+                .containsSequence("-a", "b")
+                .containsSequence("-c:v", encode.codec)
+                .noneSatisfy{ assertThat(it).containsSequence("-c", "d", "-pass", "2", "-stats", "log-vp9")}
+        } else {
+            assertThat(params).isEmpty()
+        }
+    }
+
+    override fun verifySecondPassParams(encode: VideoEncode, params: List<String>) {
+        if(encode.twoPass) {
+            assertThat(params)
+                .containsSequence("-a", "b")
+                .containsSequence("-c:v", encode.codec)
+                .containsSequence("-c", "d")
+                .containsSequence("-pass", "2")
+                .containsSequence("-stats","log-vp9")
+        } else {
+            assertThat(params)
+                .containsSequence("-a", "b")
+                .containsSequence("-c:v", encode.codec)
+                .containsSequence("-c", "d")
+                .noneSatisfy{assertThat(it).containsSequence("-pass", "2").containsSequence("-stats", "log-vp9")}
+        }
+    }
+}

--- a/src/test/kotlin/se/svt/oss/encore/service/profile/ProfileServiceTest.kt
+++ b/src/test/kotlin/se/svt/oss/encore/service/profile/ProfileServiceTest.kt
@@ -24,7 +24,7 @@ class ProfileServiceTest {
 
     @Test
     fun `successfully parses valid yaml profiles`() {
-        listOf("archive", "program-x265", "program").forEach {
+        listOf("archive", "program-x265", "program", "program-vp9").forEach {
             profileService.getProfile(it)
         }
     }
@@ -41,7 +41,7 @@ class ProfileServiceTest {
     fun `unknown profile throws error`() {
         assertThatThrownBy { profileService.getProfile("test-non-existing") }
             .isInstanceOf(RuntimeException::class.java)
-            .hasMessage("Could not find location for profile test-non-existing! Profiles: {program=program.yml, multiple-inputs=multiple_inputs.yml, dpb_size_failed=dpb_size_failed.yml, program-x265=program-x265.yml, archive=archive.yml, test-invalid=test_profile_invalid.yml, test-invalid-location=test_profile_invalid_location.yml, none=null}")
+            .hasMessage("Could not find location for profile test-non-existing! Profiles: {program=program.yml, multiple-inputs=multiple_inputs.yml, dpb_size_failed=dpb_size_failed.yml, program-x265=program-x265.yml, program-vp9=program-vp9.yml, archive=archive.yml, test-invalid=test_profile_invalid.yml, test-invalid-location=test_profile_invalid_location.yml, none=null}")
     }
 
     @Test
@@ -63,6 +63,6 @@ class ProfileServiceTest {
     fun `profile value empty throw errrors`() {
         assertThatThrownBy { profileService.getProfile("none") }
             .isInstanceOf(RuntimeException::class.java)
-            .hasMessage("Could not find location for profile none! Profiles: {program=program.yml, multiple-inputs=multiple_inputs.yml, dpb_size_failed=dpb_size_failed.yml, program-x265=program-x265.yml, archive=archive.yml, test-invalid=test_profile_invalid.yml, test-invalid-location=test_profile_invalid_location.yml, none=null}")
+            .hasMessage("Could not find location for profile none! Profiles: {program=program.yml, multiple-inputs=multiple_inputs.yml, dpb_size_failed=dpb_size_failed.yml, program-x265=program-x265.yml, program-vp9=program-vp9.yml, archive=archive.yml, test-invalid=test_profile_invalid.yml, test-invalid-location=test_profile_invalid_location.yml, none=null}")
     }
 }

--- a/src/test/resources/profile/profiles.yml
+++ b/src/test/resources/profile/profiles.yml
@@ -2,6 +2,7 @@ program: program.yml
 multiple-inputs: multiple_inputs.yml
 dpb_size_failed: dpb_size_failed.yml
 program-x265: program-x265.yml
+program-vp9: program-vp9.yml
 archive: archive.yml
 test-invalid: test_profile_invalid.yml
 test-invalid-location: test_profile_invalid_location.yml

--- a/src/test/resources/profile/program-vp9.yml
+++ b/src/test/resources/profile/program-vp9.yml
@@ -1,0 +1,97 @@
+name: program-vp9
+description: VP9 profile
+scaling: bicubic
+encodes:
+  - type: Vp9Encode
+    suffix: _vp9_3000
+    twoPass: true
+    height: 1080
+    params:
+      b:v: 3000k
+      maxrate: 2610k
+      bufsize: 6000k
+      r: 25
+      pix_fmt: yuv420p10le
+    vp9-params:
+      g: 96
+      keyint_min: 96
+      rc_lookahead: 25
+      tile-columns: 6
+      frame-parallel: 1
+      quality: good
+      speed: 0
+    audioEncode:
+      type: AudioEncode
+      bitrate: 192k
+      suffix: STEREO
+
+  - type: Vp9Encode
+    suffix: _vp9_1024
+    twoPass: true
+    height: 720
+    params:
+      b:v: 1024k
+      maxrate: 1485k
+      bufsize: 2048k
+      r: 25
+      pix_fmt: yuv420p10le
+    vp9-params:
+      g: 96
+      keyint_min: 96
+      rc_lookahead: 25
+      tile-columns: 6
+      frame-parallel: 1
+      quality: good
+      speed: 0
+    audioEncode:
+      type: AudioEncode
+      bitrate: 128k
+      suffix: STEREO
+  - type: Vp9Encode
+    suffix: _vp9_865
+    twoPass: true
+    height: 540
+    params:
+      b:v: 865k
+      maxrate: 1298k
+      bufsize: 1730k
+      r: 25
+      pix_fmt: yuv420p10le
+    vp9-params:
+      g: 96
+      keyint_min: 96
+      rc_lookahead: 25
+      tile-columns: 6
+      frame-parallel: 1
+      quality: good
+      speed: 0
+    audioEncode:
+      type: AudioEncode
+      bitrate: 128k
+      suffix: STEREO
+
+  - type: Vp9Encode
+    suffix: _vp9_276
+    twoPass: true
+    height: 360
+    params:
+      b:v: 276k
+      maxrate: 400k
+      bufsize: 552k
+      r: 25
+      pix_fmt: yuv420p
+    vp9-params:
+      g: 96
+      keyint_min: 96
+      rc_lookahead: 25
+      tile-columns: 6
+      frame-parallel: 1
+      quality: good
+      speed: 0
+    audioEncode:
+      type: AudioEncode
+      bitrate: 128k
+      suffix: STEREO
+
+
+

--- a/src/test/resources/profile/program-vp9.yml
+++ b/src/test/resources/profile/program-vp9.yml
@@ -24,6 +24,7 @@ encodes:
       type: AudioEncode
       bitrate: 192k
       suffix: STEREO
+      codec: libvorbis
 
   - type: Vp9Encode
     suffix: _vp9_1024
@@ -47,6 +48,8 @@ encodes:
       type: AudioEncode
       bitrate: 128k
       suffix: STEREO
+      codec: libvorbis
+
   - type: Vp9Encode
     suffix: _vp9_865
     twoPass: true
@@ -69,6 +72,7 @@ encodes:
       type: AudioEncode
       bitrate: 128k
       suffix: STEREO
+      codec: libvorbis
 
   - type: Vp9Encode
     suffix: _vp9_276
@@ -92,6 +96,7 @@ encodes:
       type: AudioEncode
       bitrate: 128k
       suffix: STEREO
+      codec: libvorbis
 
 
 

--- a/src/test/resources/profile/program-vp9.yml
+++ b/src/test/resources/profile/program-vp9.yml
@@ -8,7 +8,7 @@ encodes:
     height: 1080
     params:
       b:v: 3000k
-      maxrate: 2610k
+      maxrate: 4500k
       bufsize: 6000k
       r: 25
       pix_fmt: yuv420p10le


### PR DESCRIPTION
### Summary
This PR adds support for video encoding using [VP9](https://en.wikipedia.org/wiki/VP9).

### Code changes

- Add abstract class `VpXEncode`, a VP9 equivalent to `X26Xencode` for x264/x265.
- Add data class `Vp9Encode`.
- Add unit tests for `Vp9Encode`.
- Modify `ProfileServiceTest` to include VP9 profiles.
- Add profile `program-vp9` to `test/resources`, as well as a reference in `profiles.yml`

### Motivation
VP9 can be seen as a royalty-free alternative to h.264 and/or h.265. Adding VP9 encoding to encore allows those who wish to avoid using proprietary codecs to transcode video with encore, and provides a slightly more efficient alternative to h.264 for targets that do not support HEVC, such as most modern browsers (safari and some versions of edge excluded).

### Compatibility
The libraries used for VP9 encoding (`libvpx` for video, `libvorbis` for audio) are included in the FFMPEG build found in [svt/homebrew-avtools](https://github.com/svt/homebrew-avtools), meaning that this PR should work without needing to change any depenencies. FFMPEG commands generated by the command builder for VP9 encodes have been tested and work without issues.