### PR TITLE
feat: add a basic github ci with docker build and push to ghchr

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
   build-artifact:
     runs-on: ubuntu-latest
     container: 
-        image: ${{ env.DOCKER_BASE_IMAGE }}
+        image: ghcr.io/janderssonse/avtools-osadl-debian:latest
         options: --user root
     permissions:
       contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,13 +8,13 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: svt-encore-debian
+  IMAGE_NAME: encore-debian
 
 jobs:
   build-artifact:
     runs-on: ubuntu-latest
     container: 
-        image: ghcr.io/janderssonse/avtools-debian
+        image: ghcr.io/janderssonse/avtools-osadl-debian
         options: --user root
     permissions:
       contents: read
@@ -35,12 +35,6 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build -x test
-
-####### # - name: Upload build
-####### uses: actions/upload-artifact@v2
-####### with:
-#######    name: builddir
-#######    path: build/libs/encore*.jar
 
       - name: cache build
         uses: actions/cache@v2
@@ -67,11 +61,6 @@ jobs:
           path: ./build
           key: ${{ github.sha }}
       - run: ls ./build    
-#     - name: Download Build
-#       id: download
-#       uses: actions/download-artifact@v2
-#       with:
-#          name: builddir
 
       - name: 'Echo download path'
         run: echo ${{steps.download.outputs.download-path}}
@@ -101,18 +90,10 @@ jobs:
         with:
           context: .
           build-args: |
-                  DOCKER_BASE_IMAGE=ghcr.io/janderssonse/avtools-debian:latest
+                  DOCKER_BASE_IMAGE=ghcr.io/janderssonse/avtools-osadl-debian:latest
                   USR=avtools
           platforms: x86_64
-          no-cache: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           
-          #registry: ${{ env.REGISTRY }}
-          #username: ${{ github.actor }}
-          #password: ${{ secrets.GITHUB_TOKEN }}
-          #repository: ghcr.io/janderssonse/encore 
-          #always_pull: true
-          #build_args: DOCKER_BASE_IMAGE=ghcr.io/janderssonse/avtools-debian-squash,ARTIFACTDIR=
-          #tag_with_ref: true 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,13 +9,14 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: encore-debian
+  DOCKER_BASE_IMAGE: ghcr.io/janderssonse/avtools-osadl-debian:latest
 
 jobs:
   build-artifact:
     runs-on: ubuntu-latest
     container: 
-        image: ghcr.io/janderssonse/avtools-osadl-debian
-        options: --user avtools
+    image: ${{ env.DOCKER_BASE_IMAGE }}
+        options: --user root
     permissions:
       contents: read
       packages: write
@@ -90,7 +91,7 @@ jobs:
         with:
           context: .
           build-args: |
-                  DOCKER_BASE_IMAGE=ghcr.io/janderssonse/avtools-osadl-debian:latest
+                  DOCKER_BASE_IMAGE=${{ env.DOCKER_BASE_IMAGE }} 
                   USR=avtools
           platforms: x86_64
           push: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['master','main','basicgithubci']
+    branches: ['master','main']
     tags:
       - 'v*'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
   build-artifact:
     runs-on: ubuntu-latest
     container: 
-    image: ${{ env.DOCKER_BASE_IMAGE }}
+        image: ${{ env.DOCKER_BASE_IMAGE }}
         options: --user root
     permissions:
       contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 
         image: ghcr.io/janderssonse/avtools-osadl-debian
-        options: --user root
+        options: --user avtools
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,13 +9,13 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: encore-debian
-  DOCKER_BASE_IMAGE: ghcr.io/janderssonse/avtools-osadl-debian:latest
+  DOCKER_BASE_IMAGE: ghcr.io/svt/avtools-osadl-debian:latest
 
 jobs:
   build-artifact:
     runs-on: ubuntu-latest
     container: 
-        image: ghcr.io/janderssonse/avtools-osadl-debian:latest
+        image: ghcr.io/svt/avtools-osadl-debian:latest
         options: --user root
     permissions:
       contents: read

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: encore-debian
-  DOCKER_BASE_IMAGE: ghcr.io/svt/avtools-osadl-debian:latest
+  DOCKER_BASE_IMAGE: ghcr.io/svt/avtools-osadl-jre-debian:latest
 
 jobs:
   build-artifact:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,118 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master','main','basicgithubci']
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: svt-encore-debian
+
+jobs:
+  build-artifact:
+    runs-on: ubuntu-latest
+    container: 
+        image: ghcr.io/janderssonse/avtools-debian
+        options: --user root
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+####### # - name: Upload build
+####### uses: actions/upload-artifact@v2
+####### with:
+#######    name: builddir
+#######    path: build/libs/encore*.jar
+
+      - name: cache build
+        uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./build
+          key: ${{ github.sha }}
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    needs: build-artifact
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+  
+      - name: Get Cache Build 
+        uses: actions/cache@v2
+        id: restore-build
+        with:
+          path: ./build
+          key: ${{ github.sha }}
+      - run: ls ./build    
+#     - name: Download Build
+#       id: download
+#       uses: actions/download-artifact@v2
+#       with:
+#          name: builddir
+
+      - name: 'Echo download path'
+        run: echo ${{steps.download.outputs.download-path}}
+      
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value={{branch}},priority=1,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag,priority=2
+            type=raw,value=${{ env.IMAGE_NAME }}-{{branch}}-{{date 'YYYYMMDD'}}-{{sha}},priority=31,enable=${{ !startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ env.IMAGE_NAME }}-{{tag}}-{{date 'YYYYMMDD'}}-{{sha}},priority=32, enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+                  DOCKER_BASE_IMAGE=ghcr.io/janderssonse/avtools-debian:latest
+                  USR=avtools
+          platforms: x86_64
+          no-cache: true
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          
+          #registry: ${{ env.REGISTRY }}
+          #username: ${{ github.actor }}
+          #password: ${{ secrets.GITHUB_TOKEN }}
+          #repository: ghcr.io/janderssonse/encore 
+          #always_pull: true
+          #build_args: DOCKER_BASE_IMAGE=ghcr.io/janderssonse/avtools-debian-squash,ARTIFACTDIR=
+          #tag_with_ref: true 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,24 @@
 ARG DOCKER_BASE_IMAGE
 FROM ${DOCKER_BASE_IMAGE}
 
-COPY build/libs/encore.jar /app/encore.jar
-COPY bin/start.sh /app/start.sh
+LABEL org.opencontainers.image.url="https://github.com/janderssonse/encore"
+LABEL org.opencontainers.image.source="https://github.com/janderssonse/encore"
+LABEL org.opencontainers.image.title="svt-encore-debian"
+
+ARG ARTIFACTDIR="build/libs"
+ARG USR="root"
+ARG JRE="openjdk-11-jre-headless"
+
+USER root
+
+RUN apt-get update --allow-releaseinfo-change && \ 
+  apt-get install -yq --no-install-recommends ${JRE} && \
+  apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
+
+USER ${USR}
+
+COPY --chown=${USR}:${USR} ${ARTIFACTDIR}/encore.jar /app/encore.jar
+COPY --chown=${USR}:${USR} bin/start.sh /app/start.sh
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,8 @@ FROM ${DOCKER_BASE_IMAGE}
 
 LABEL org.opencontainers.image.url="https://github.com/janderssonse/encore"
 LABEL org.opencontainers.image.source="https://github.com/janderssonse/encore"
-LABEL org.opencontainers.image.title="svt-encore-debian"
+LABEL org.opencontainers.image.title="encore-debian"
 
-ARG ARTIFACTDIR="build/libs"
 ARG USR="root"
 ARG JRE="openjdk-11-jre-headless"
 
@@ -17,7 +16,7 @@ RUN apt-get update --allow-releaseinfo-change && \
 
 USER ${USR}
 
-COPY --chown=${USR}:${USR} ${ARTIFACTDIR}/encore.jar /app/encore.jar
+COPY --chown=${USR}:${USR} build/libs/encore.jar /app/encore.jar
 COPY --chown=${USR}:${USR} bin/start.sh /app/start.sh
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,21 +3,9 @@ FROM ${DOCKER_BASE_IMAGE}
 
 LABEL org.opencontainers.image.url="https://github.com/svt/encore"
 LABEL org.opencontainers.image.source="https://github.com/svt/encore"
-LABEL org.opencontainers.image.title="encore-debian"
 
-ARG USR="root"
-ARG JRE="openjdk-11-jre-headless"
-
-USER root
-
-RUN apt-get update --allow-releaseinfo-change && \ 
-  apt-get install -yq --no-install-recommends ${JRE} && \
-  apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*
-
-USER ${USR}
-
-COPY --chown=${USR}:${USR} build/libs/encore.jar /app/encore.jar
-COPY --chown=${USR}:${USR} bin/start.sh /app/start.sh
+COPY build/libs/encore.jar /app/encore.jar
+COPY bin/start.sh /app/start.sh
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG DOCKER_BASE_IMAGE
 FROM ${DOCKER_BASE_IMAGE}
 
-LABEL org.opencontainers.image.url="https://github.com/janderssonse/encore"
-LABEL org.opencontainers.image.source="https://github.com/janderssonse/encore"
+LABEL org.opencontainers.image.url="https://github.com/svt/encore"
+LABEL org.opencontainers.image.source="https://github.com/svt/encore"
 LABEL org.opencontainers.image.title="encore-debian"
 
 ARG USR="root"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,29 @@
 service:
   name: encore-local
 
-profile:
-  location: url:http://localhost/profiles.yml
+spring:
+  redis:
+    host: localhost
+    port: 6379
 
+profile:
+  location: url:https://raw.githubusercontent.com/svt/encore/master/src/test/resources/profile/profiles.yml
+
+
+encore-settings:
+  concurrency: 3
+  local-temporary-encode: false
+  poll-initial-delay: 1s
+  poll-delaly: 1s
+
+  audio-mix-presets:
+    default:
+      pan-mapping:
+        6:
+          2: stereo|c0=1.0*c0+0.707*c2+0.707*c4|c1=1.0*c1+0.707*c2+0.707*c5
+    de:
+      fallback-to-auto: false
+      pan-mapping:
+        6:
+          2: stereo|c0<0.25*c0+1.5*c2+0.25*c4|c1<0.25*c1+1.5*c2+0.25*c5
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,7 +9,6 @@ spring:
 profile:
   location: url:https://raw.githubusercontent.com/svt/encore/master/src/test/resources/profile/profiles.yml
 
-
 encore-settings:
   concurrency: 3
   local-temporary-encode: false
@@ -22,8 +21,4 @@ encore-settings:
         6:
           2: stereo|c0=1.0*c0+0.707*c2+0.707*c4|c1=1.0*c1+0.707*c2+0.707*c5
     de:
-      fallback-to-auto: false
-      pan-mapping:
-        6:
-          2: stereo|c0<0.25*c0+1.5*c2+0.25*c4|c1<0.25*c1+1.5*c2+0.25*c5
-
+      fallback-to-auto: true


### PR DESCRIPTION
## Description

This PR adds a simple GitHub that builds a Docker Build. This is part of an ongoing action to simplify testing Encore in general. For example, the same CI could be used to publish a jar in the future.
The Encore Documentation has an [PR](https://github.com/svt/encore-doc/pull/19 ) related to this that should be merged at the same time.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

In the documentation, there is an example docker-compose file. The docker-build resulting from this change has been tested on Linux, macos (big sur, intel) and the internal CI-pipeline where it was used to encode test files (with the addition of libfdk- which is not in the base image of this build).

## Checklist:

- [x] confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

