### PR TITLE
feat: add support for including complete profile in job

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/ReflectionConfiguration.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/ReflectionConfiguration.kt
@@ -1,0 +1,33 @@
+package se.svt.oss.encore
+
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding
+import org.springframework.context.annotation.Configuration
+import se.svt.oss.encore.model.profile.AudioEncode
+import se.svt.oss.encore.model.profile.AudioEncoder
+import se.svt.oss.encore.model.profile.GenericVideoEncode
+import se.svt.oss.encore.model.profile.OutputProducer
+import se.svt.oss.encore.model.profile.Profile
+import se.svt.oss.encore.model.profile.SimpleAudioEncode
+import se.svt.oss.encore.model.profile.ThumbnailEncode
+import se.svt.oss.encore.model.profile.ThumbnailMapEncode
+import se.svt.oss.encore.model.profile.VideoEncode
+import se.svt.oss.encore.model.profile.X264Encode
+import se.svt.oss.encore.model.profile.X265Encode
+import se.svt.oss.encore.model.profile.X26XEncode
+
+@RegisterReflectionForBinding(
+    AudioEncode::class,
+    AudioEncoder::class,
+    GenericVideoEncode::class,
+    OutputProducer::class,
+    Profile::class,
+    SimpleAudioEncode::class,
+    ThumbnailEncode::class,
+    ThumbnailMapEncode::class,
+    VideoEncode::class,
+    X26XEncode::class,
+    X264Encode::class,
+    X265Encode::class
+)
+@Configuration
+class ReflectionConfiguration

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/EncoreJob.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/EncoreJob.kt
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.Positive
+import se.svt.oss.encore.model.profile.Profile
 
 @Validated
 @RedisHash("encore-jobs", timeToLive = (60 * 60 * 24 * 7).toLong()) // 1 week ttl
@@ -46,10 +47,12 @@ data class EncoreJob(
     @Schema(
         description = "The name of the encoding profile to use",
         example = "x264-animated",
-        required = true
+        nullable = true
     )
-    @NotBlank
-    val profile: String,
+    val profile: String? = null,
+
+    @Schema(description = "Inline transcoding profile. If set, the profile field will be ignored", nullable = true)
+    val inlineProfile: Profile? = null,
 
     @Schema(
         description = "A directory path to where the output should be written",
@@ -168,7 +171,8 @@ data class EncoreJob(
     val thumbnailTime: Double? = null,
 
     @NotEmpty
-    val inputs: List<Input> = emptyList()
+    val inputs: List<Input> = emptyList(),
+
 ) {
 
     @Schema(
@@ -199,6 +203,6 @@ data class EncoreJob(
             "id" to id.toString(),
             "file" to baseName,
             "externalId" to (externalId ?: ""),
-            "profile" to profile
+            "profile" to (profile ?: inlineProfile?.name ?: "")
         ) + logContext
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncoder.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncoder.kt
@@ -7,10 +7,14 @@ package se.svt.oss.encore.model.profile
 import mu.KotlinLogging
 import se.svt.oss.encore.model.output.Output
 
+private val log = KotlinLogging.logger { }
+
 abstract class AudioEncoder : OutputProducer {
-    private val log = KotlinLogging.logger { }
 
     abstract val optional: Boolean
+
+    override val type: String
+        get() = this.javaClass.simpleName
 
     fun logOrThrow(message: String): Output? {
         if (optional) {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/GenericVideoEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/GenericVideoEncode.kt
@@ -18,4 +18,7 @@ data class GenericVideoEncode(
     override val format: String,
     override val codec: String,
     override val inputLabel: String = DEFAULT_VIDEO_LABEL
-) : VideoEncode
+) : VideoEncode {
+    override val type: String
+        get() = this.javaClass.simpleName
+}

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/GenericVideoEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/GenericVideoEncode.kt
@@ -18,7 +18,7 @@ data class GenericVideoEncode(
     override val format: String,
     override val codec: String,
     override val inputLabel: String = DEFAULT_VIDEO_LABEL
-) : VideoEncode {
+) : VideoEncode() {
     override val type: String
         get() = this.javaClass.simpleName
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
@@ -10,7 +10,7 @@ import se.svt.oss.encore.config.EncodingProperties
 import se.svt.oss.encore.model.EncoreJob
 import se.svt.oss.encore.model.output.Output
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
 @JsonSubTypes(
     JsonSubTypes.Type(value = AudioEncode::class, name = "AudioEncode"),
     JsonSubTypes.Type(value = SimpleAudioEncode::class, name = "SimpleAudioEncode"),
@@ -22,4 +22,6 @@ import se.svt.oss.encore.model.output.Output
 )
 interface OutputProducer {
     fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output?
+
+    val type: String
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncode.kt
@@ -14,6 +14,8 @@ import se.svt.oss.encore.model.mediafile.toParams
 import se.svt.oss.encore.model.output.Output
 import se.svt.oss.encore.model.output.VideoStreamEncode
 
+private val log = KotlinLogging.logger { }
+
 data class ThumbnailEncode(
     val percentages: List<Int> = listOf(25, 50, 75),
     val thumbnailWidth: Int = -2,
@@ -26,7 +28,8 @@ data class ThumbnailEncode(
     val intervalSeconds: Double? = null
 ) : OutputProducer {
 
-    private val log = KotlinLogging.logger { }
+    override val type: String
+        get() = this.javaClass.simpleName
 
     override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
         if (job.segmentLength != null) {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncode.kt
@@ -17,6 +17,8 @@ import se.svt.oss.encore.model.output.VideoStreamEncode
 import se.svt.oss.mediaanalyzer.file.stringValue
 import kotlin.io.path.createTempDirectory
 
+private val log = KotlinLogging.logger { }
+
 data class ThumbnailMapEncode(
     val tileWidth: Int = 160,
     val tileHeight: Int = 90,
@@ -28,7 +30,8 @@ data class ThumbnailMapEncode(
     val inputLabel: String = DEFAULT_VIDEO_LABEL
 ) : OutputProducer {
 
-    private val log = KotlinLogging.logger { }
+    override val type: String
+        get() = this.javaClass.simpleName
 
     override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
         if (job.segmentLength != null) {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/VideoEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/VideoEncode.kt
@@ -14,18 +14,18 @@ import se.svt.oss.encore.model.output.Output
 import se.svt.oss.encore.model.output.VideoStreamEncode
 import se.svt.oss.mediaanalyzer.file.toFractionOrNull
 
-interface VideoEncode : OutputProducer {
-    val width: Int?
-    val height: Int?
-    val twoPass: Boolean
-    val params: Map<String, String>
-    val filters: List<String>?
-    val audioEncode: AudioEncoder?
-    val audioEncodes: List<AudioEncoder>
-    val suffix: String
-    val format: String
-    val codec: String
-    val inputLabel: String
+abstract class VideoEncode : OutputProducer {
+    abstract val width: Int?
+    abstract val height: Int?
+    abstract val twoPass: Boolean
+    abstract val params: Map<String, String>
+    abstract val filters: List<String>?
+    abstract val audioEncode: AudioEncoder?
+    abstract val audioEncodes: List<AudioEncoder>
+    abstract val suffix: String
+    abstract val format: String
+    abstract val codec: String
+    abstract val inputLabel: String
 
     override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
         val audioEncodesToUse = audioEncodes.ifEmpty { listOfNotNull(audioEncode) }
@@ -62,7 +62,7 @@ interface VideoEncode : OutputProducer {
         }
     }
 
-    fun passParams(pass: Int): Map<String, String> =
+    open fun passParams(pass: Int): Map<String, String> =
         mapOf("pass" to pass.toString(), "passlogfile" to "log$suffix")
 
     private fun videoFilter(

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/X26XEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/X26XEncode.kt
@@ -4,7 +4,7 @@
 
 package se.svt.oss.encore.model.profile
 
-abstract class X26XEncode : VideoEncode {
+abstract class X26XEncode : VideoEncode() {
 
     abstract val ffmpegParams: LinkedHashMap<String, String>
 

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/X26XEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/X26XEncode.kt
@@ -11,6 +11,9 @@ abstract class X26XEncode : VideoEncode {
     abstract val codecParams: LinkedHashMap<String, String>
     abstract val codecParamName: String
 
+    override val type: String
+        get() = this.javaClass.simpleName
+
     override val params: Map<String, String>
         get() = ffmpegParams + if (codecParams.isNotEmpty()) {
             mapOf(codecParamName to codecParams.map { "${it.key}=${it.value}" }.joinToString(":"))

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/ProfileJsonTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/ProfileJsonTest.kt
@@ -1,0 +1,57 @@
+package se.svt.oss.encore.model.profile
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.junit.jupiter.api.Test
+import se.svt.oss.encore.model.profile.ProfileAssert.assertThat
+
+class ProfileJsonTest {
+
+    private val yamlMapper = YAMLMapper().findAndRegisterModules().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    private val objectMapper = ObjectMapper().findAndRegisterModules().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+
+    @Test
+    fun testSerializeProgramToJson() {
+        serializeDeserializeJson(readProfile("/profile/program.yml"))
+    }
+
+    @Test
+    fun testSerializeProgramX265ToJson() {
+        serializeDeserializeJson(readProfile("/profile/program-x265.yml"))
+    }
+
+    @Test
+    fun testSerializeProgramToYaml() {
+        serializeDeserializeYaml(readProfile("/profile/program.yml"))
+    }
+
+    @Test
+    fun testSerializeProgramX265ToYaml() {
+        serializeDeserializeYaml(readProfile("/profile/program-x265.yml"))
+    }
+
+    private fun serializeDeserializeJson(profile: Profile) {
+        val pretty = ObjectMapper().findAndRegisterModules().writerWithDefaultPrettyPrinter()
+        println(pretty.writeValueAsString(profile))
+        val serialized = objectMapper.writeValueAsString(profile)
+        val deserialized: Profile = objectMapper.readValue(serialized, Profile::class.java)
+        assertThat(deserialized)
+            .isEqualTo(profile)
+    }
+
+    private fun serializeDeserializeYaml(profile: Profile) {
+        val pretty = YAMLMapper().findAndRegisterModules().writerWithDefaultPrettyPrinter()
+        println(pretty.writeValueAsString(profile))
+        val serialized = yamlMapper.writeValueAsString(profile)
+        val deserialized: Profile = yamlMapper.readValue(serialized, Profile::class.java)
+        assertThat(deserialized)
+            .isEqualTo(profile)
+    }
+
+    private fun readProfile(path: String): Profile =
+        ProfileJsonTest::class.java.getResourceAsStream(path).use {
+            yamlMapper.readValue(it)
+        }
+}


### PR DESCRIPTION
## Description

Support for providing an encoding profile inside a submitted job has been added.

A new field `inlineProfile` has been added to `EncoreJob`. In this field a complete profile can be included, in which case this profile is used instead of the one specified in the `profile` field. Exactly one of 'profile' and 'inlineProfile' should be specified..

Non-functional changes have been made to the classes of the `OutputProducer` hierarchy to make serialization/deserialization and persistance work.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

An test using an inline profile has been added to the `EncoreIntegrationTest` test class.

## Checklist:

- [x] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

