### PR TITLE
fix: add configuration property that allows disabling setting of noti…

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/RedisConfiguration.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/RedisConfiguration.kt
@@ -43,7 +43,10 @@ import se.svt.oss.mediaanalyzer.file.VideoFile
     SegmentProgressEvent::class,
     QueueItem::class
 )
-@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
+@EnableRedisRepositories(
+    enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP,
+    keyspaceNotificationsConfigParameter = "#{\${redis.keyspace.disable-config-notifications:false} ? '' : 'Ex'}"
+)
 class RedisConfiguration {
 
     @Bean


### PR DESCRIPTION
Fix issue #25 Encore fails to start if redis server is not configured to allow CONFIG command

Before this fix, when starting encore, spring data redis would try to use the CONFIG command to set notify-keyspace-events on the redis server. If the server did not support the CONFIG command, which is the case in many managed redis services, encore would fail to start.

With this fix, setting the property redis.keyspace.disable-config-notifications to true string will stop spring data redis from trying to change the config. If the property is not set, or set to false, spring data redis will behave as before, that is use the CONFIG command to set 'notify-keyspace-events'.

Note that this fix does not seem to solve the issue when native compile is used.

