### PR TITLE
feat: support for input with mix of mono and multitrack audiostreams

### DIFF
--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/mediafile/AudioLayout.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/mediafile/AudioLayout.kt
@@ -6,7 +6,7 @@ package se.svt.oss.encore.model.mediafile
 
 enum class AudioLayout {
     NONE,
-    INVALID,
+    MIXED_MONO_MULTI,
     MONO_STREAMS,
     MULTI_TRACK,
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncode.kt
@@ -36,9 +36,6 @@ data class AudioEncode(
         val audioIn = job.inputs.audioInput(inputLabel)
             ?: return logOrThrow("Can not generate $outputName! No audio input with label '$inputLabel'.")
         val analyzed = audioIn.analyzedAudio
-        if (analyzed.audioLayout() == AudioLayout.INVALID) {
-            throw RuntimeException("Audio layout of audio input '$inputLabel' is not supported!")
-        }
         if (analyzed.audioLayout() == AudioLayout.NONE) {
             return logOrThrow("Can not generate $outputName! No audio streams in input!")
         }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/process/CommandBuilder.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/process/CommandBuilder.kt
@@ -217,13 +217,16 @@ class CommandBuilder(
         return filters + input.videoFilters
     }
 
-    private fun globalAudioFilters(input: AudioIn, analyzed: MediaContainer): List<String> = if (analyzed.audioLayout() == AudioLayout.MONO_STREAMS) {
-        val channelLayout = input.channelLayout(encodingProperties.defaultChannelLayouts)
-        val map = channelLayout.channels.withIndex().joinToString("|") { "${it.index}.0-${it.value}" }
-        listOf("join=inputs=${channelLayout.channels.size}:channel_layout=${channelLayout.layoutName}:map=$map")
-    } else {
-        emptyList()
-    } + input.audioFilters
+    private fun globalAudioFilters(input: AudioIn, analyzed: MediaContainer): List<String> =
+        if (analyzed.audioLayout() == AudioLayout.MONO_STREAMS ||
+            analyzed.audioLayout() == AudioLayout.MIXED_MONO_MULTI
+        ) {
+            val channelLayout = input.channelLayout(encodingProperties.defaultChannelLayouts)
+            val map = channelLayout.channels.withIndex().joinToString("|") { "${it.index}.0-${it.value}" }
+            listOf("join=inputs=${channelLayout.channels.size}:channel_layout=${channelLayout.layoutName}:map=$map")
+        } else {
+            emptyList()
+        } + input.audioFilters
 
     private fun firstPassParams(output: Output): List<String> {
         if (output.video == null) {

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/model/mediafile/MediaFileExtensionsTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/model/mediafile/MediaFileExtensionsTest.kt
@@ -18,7 +18,7 @@ import se.svt.oss.mediaanalyzer.file.MediaFile
 internal class MediaFileExtensionsTest {
     private val noAudio = defaultVideoFile.copy(audioStreams = emptyList())
 
-    private val invalidAudio = defaultVideoFile.copy(
+    private val mixedMonoMultiAudio = defaultVideoFile.copy(
         audioStreams = defaultVideoFile.audioStreams.mapIndexed { index, audioStream ->
             if (index == 0) audioStream else audioStream.copy(channels = 2)
         },
@@ -53,9 +53,9 @@ internal class MediaFileExtensionsTest {
     }
 
     @Test
-    @DisplayName("Audio layout is invalid if first stream has one channel and the rest has two channels or more")
-    fun testAudioLayoutInvalid() {
-        assertThat(invalidAudio.audioLayout()).isEqualTo(AudioLayout.INVALID)
+    @DisplayName("Audio layout is MIXED_MONO_MULTI if first stream has one channel and the rest has two channels or more")
+    fun testAudioLayoutMonotracksFollowedByMultitrack() {
+        assertThat(mixedMonoMultiAudio.audioLayout()).isEqualTo(AudioLayout.MIXED_MONO_MULTI)
     }
 
     @Test
@@ -70,6 +70,12 @@ internal class MediaFileExtensionsTest {
     @DisplayName("Channel count for mono streams is number of streams")
     fun testChannelCountMonoSteams() {
         assertThat(defaultVideoFile.channelCount()).isEqualTo(8)
+    }
+
+    @Test
+    @DisplayName("Channel count for mono stream followed by multitrack streams is equal to number of leading mono streams")
+    fun testChannelCountMixedMonoMultiStreams() {
+        assertThat(mixedMonoMultiAudio.channelCount()).isEqualTo(1)
     }
 
     @Test
@@ -146,13 +152,6 @@ internal class MediaFileExtensionsTest {
     @DisplayName("Channel layout throws when no audio")
     fun channelLayoutNoAudio() {
         assertThatThrownBy { audioInput(noAudio).channelLayout(defaultChannelLayouts) }
-            .hasMessage("Could not determine channel layout for audio input 'main'!")
-    }
-
-    @Test
-    @DisplayName("Channel layout throws when invalid audio")
-    fun channelLayoutInvalidAudio() {
-        assertThatThrownBy { audioInput(invalidAudio).channelLayout(defaultChannelLayouts) }
             .hasMessage("Could not determine channel layout for audio input 'main'!")
     }
 

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/AudioEncodeTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/AudioEncodeTest.kt
@@ -36,18 +36,6 @@ class AudioEncodeTest {
     }
 
     @Test
-    fun `not supported soundtype throws exception`() {
-        val job = job(getAudioStream(1), getAudioStream(2))
-        assertThatThrownBy {
-            audioEncode.getOutput(
-                job,
-                EncodingProperties(audioMixPresets = mapOf("default" to AudioMixPreset(fallbackToAuto = false))),
-            )
-        }.isInstanceOf(RuntimeException::class.java)
-            .hasMessage("Audio layout of audio input 'main' is not supported!")
-    }
-
-    @Test
     fun `valid output`() {
         val output = audioEncode.getOutput(
             job(getAudioStream(6)),


### PR DESCRIPTION
## Description
It seems to be reasonably common to store a multitrack (stereo) 'Dolby E' stream together with multiple other mono streams in an MXF file. Previously, encore would fail the job if the input had a mix of mono and multitrack audiostreams, except if the first stream was multitrack. This feat adds some support for inputs with a mix of mono and multitrack streams, where the first stream is a mono stream. Given such an input, encore now uses all mono streams that comes before the first multitrack stream, and ignore all following audiostreams.

Note that the support for mixed multi-/monotrack streams is limited in the sense that it does not allow use of all input streams in such a case, only the monostreams that comes before the first multitrack stream can be used. A more complete solution was deemed to complex at the moment.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Some unit tests has been added
- No integration test was added due to difficulties of finding a suitable test file that could be publicly shared.
- Feat has been tested manually and has been running in production for a few months without problems surfacing.

## Checklist:

- [X] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)

