### PR TITLE
fix: springdoc-openapi-starter-webmvc-ui from 2.6.0 to 2.7.0

### DIFF
--- a/encore-web/build.gradle.kts
+++ b/encore-web/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation(project(":encore-common"))
     implementation("org.springframework.boot:spring-boot-starter-data-rest")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")


### PR DESCRIPTION
#35 http 500 error with /v3/api-docs 

## Description

Version update for : springdoc-openapi-starter-webmvc-ui from 2.6.0 to 2.7.0 in encore-web module.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

 Built a new jar file after updating the version and it fires up the swagger ui with all the endpoints for testing.

- [X] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)