### PR TITLE
feat: support for specifiying custom filters for split,scale,crop,pad

### DIFF
--- a/checks.gradle
+++ b/checks.gradle
@@ -15,6 +15,7 @@ jacocoTestCoverageVerification {
                     '*QueueService.migrateQueues()',
                     '*.ShutdownHandler.*',
                     '*FfmpegExecutor.runFfmpeg$lambda$?(java.lang.Process)',
+                    '*FilterSettings.*',
             ]
             limit {
                 counter = 'LINE'

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/AudioEncode.kt
@@ -32,7 +32,11 @@ data class AudioEncode(
     override val enabled: Boolean = true,
 ) : AudioEncoder() {
 
-    override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
+    override fun getOutput(
+        job: EncoreJob,
+        encodingProperties: EncodingProperties,
+        filterSettings: FilterSettings,
+    ): Output? {
         val outputName = "${job.baseName}$suffix.$format"
         if (!enabled) {
             return logOrThrow("$outputName is disabled. Skipping...")

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/OutputProducer.kt
@@ -21,5 +21,5 @@ import se.svt.oss.encore.model.output.Output
     JsonSubTypes.Type(value = ThumbnailMapEncode::class, name = "ThumbnailMapEncode"),
 )
 interface OutputProducer {
-    fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output?
+    fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties, filterSettings: FilterSettings): Output?
 }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/Profile.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/Profile.kt
@@ -10,5 +10,26 @@ data class Profile(
     val encodes: List<OutputProducer>,
     val scaling: String? = "bicubic",
     val deinterlaceFilter: String = "yadif",
+    val filterSettings: FilterSettings = FilterSettings(),
     val joinSegmentParams: LinkedHashMap<String, Any?> = linkedMapOf(),
+)
+
+data class FilterSettings(
+    /**
+     * The splitFilter property will be treated differently depending on if the values contains a '=' or not.
+     * If no '=' is included, the value is treated as the name of the filter to use and something like
+     * 'SPLITFILTERVALUE=N[ou1][out2]...' will be added to the filtergraph, where N is the number of
+     * relevant outputs in the profile.
+     * If an '=' is included, the value is assumed to already include the size parameters and something like
+     * 'SPLITFILTERVALUE[ou1][out2]...' will be added to the filtergraph. Care must be taken to ensure that the
+     * size parameters match the number of relevant outputs in the profile.
+     * This latter form of specifying the split filter can be useful for
+     * certain custom split filters that allow extra parameters, ie ni_quadra_split filter for netinit quadra
+     * cards which allows access to scaled output from the decoder.
+     */
+    val splitFilter: String = "split",
+    val scaleFilter: String = "scale",
+    val scaleFilterParams: LinkedHashMap<String, String> = linkedMapOf(),
+    val cropFilter: String = "crop",
+    val padFilter: String = "pad",
 )

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/SimpleAudioEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/SimpleAudioEncode.kt
@@ -23,7 +23,11 @@ data class SimpleAudioEncode(
     val format: String = "mp4",
     val inputLabel: String = DEFAULT_AUDIO_LABEL,
 ) : AudioEncoder() {
-    override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
+    override fun getOutput(
+        job: EncoreJob,
+        encodingProperties: EncodingProperties,
+        filterSettings: FilterSettings,
+    ): Output? {
         val outputName = "${job.baseName}$suffix.$format"
         if (!enabled) {
             return logOrThrow("$outputName is disabled. Skipping...")

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncode.kt
@@ -30,7 +30,11 @@ data class ThumbnailEncode(
     val decodeOutput: Int? = null,
 ) : OutputProducer {
 
-    override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
+    override fun getOutput(
+        job: EncoreJob,
+        encodingProperties: EncodingProperties,
+        filterSettings: FilterSettings,
+    ): Output? {
         if (!enabled) {
             return logOrThrow("Thumbnail with suffix $suffix is disabled. Skipping...")
         }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncode.kt
@@ -33,7 +33,11 @@ data class ThumbnailMapEncode(
     val decodeOutput: Int? = null,
 ) : OutputProducer {
 
-    override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
+    override fun getOutput(
+        job: EncoreJob,
+        encodingProperties: EncodingProperties,
+        filterSettings: FilterSettings,
+    ): Output? {
         if (!enabled) {
             return logOrThrow("Thumbnail map with suffix $suffix is disabled. Skipping...")
         }

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/VideoEncode.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/model/profile/VideoEncode.kt
@@ -38,13 +38,13 @@ interface VideoEncode : OutputProducer {
     val cropTo: FractionString?
     val padTo: FractionString?
 
-    override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties): Output? {
+    override fun getOutput(job: EncoreJob, encodingProperties: EncodingProperties, filterSettings: FilterSettings): Output? {
         if (!enabled) {
             log.info { "Encode $suffix is not enabled. Skipping." }
             return null
         }
         val audioEncodesToUse = audioEncodes.ifEmpty { listOfNotNull(audioEncode) }
-        val audio = audioEncodesToUse.flatMap { it.getOutput(job, encodingProperties)?.audioStreams.orEmpty() }
+        val audio = audioEncodesToUse.flatMap { it.getOutput(job, encodingProperties, filterSettings)?.audioStreams.orEmpty() }
         val videoInput = job.inputs.videoInput(inputLabel)
             ?: return logOrThrow("No valid video input with label $inputLabel!")
         return Output(
@@ -54,7 +54,7 @@ interface VideoEncode : OutputProducer {
                 firstPassParams = firstPassParams().toParams(),
                 inputLabels = listOf(inputLabel),
                 twoPass = twoPass,
-                filter = videoFilter(job.debugOverlay, encodingProperties, videoInput),
+                filter = videoFilter(job.debugOverlay, encodingProperties, videoInput, filterSettings),
             ),
             audioStreams = audio,
             output = "${job.baseName}$suffix.$format",
@@ -80,10 +80,11 @@ interface VideoEncode : OutputProducer {
         debugOverlay: Boolean,
         encodingProperties: EncodingProperties,
         videoInput: VideoIn,
+        filterSettings: FilterSettings,
     ): String? {
         val videoFilters = mutableListOf<String>()
         cropTo?.toFraction()?.let {
-            videoFilters.add("crop=min(iw\\,ih*${it.stringValue()}):min(ih\\,iw/(${it.stringValue()}))")
+            videoFilters.add("${filterSettings.cropFilter}=min(iw\\,ih*${it.stringValue()}):min(ih\\,iw/(${it.stringValue()}))")
         }
         var scaleToWidth = width
         var scaleToHeight = height
@@ -100,13 +101,31 @@ interface VideoEncode : OutputProducer {
             scaleToHeight = width
         }
         if (scaleToWidth != null && scaleToHeight != null) {
-            videoFilters.add("scale=$scaleToWidth:$scaleToHeight:force_original_aspect_ratio=decrease:force_divisible_by=2")
+            val scaleParams = listOf(
+                "$scaleToWidth",
+                "$scaleToHeight",
+            ) + (
+                linkedMapOf<String, String>(
+                    "force_original_aspect_ratio" to "decrease",
+                    "force_divisible_by" to "2",
+                ) + filterSettings.scaleFilterParams
+                )
+                .map { "${it.key}=${it.value}" }
+            videoFilters.add(
+                "${filterSettings.scaleFilter}=${scaleParams.joinToString(":") }",
+            )
             videoFilters.add("setsar=1/1")
         } else if (scaleToWidth != null || scaleToHeight != null) {
-            videoFilters.add("scale=${scaleToWidth ?: -2}:${scaleToHeight ?: -2}")
+            val filterParams = listOf(
+                scaleToWidth?.toString() ?: "-2",
+                scaleToHeight?.toString() ?: "-2",
+            ) + filterSettings.scaleFilterParams.map { "${it.key}=${it.value}" }
+            videoFilters.add(
+                "${filterSettings.scaleFilter}=${filterParams.joinToString(":") }",
+            )
         }
         padTo?.toFraction()?.let {
-            videoFilters.add("pad=aspect=${it.stringValue()}:x=(ow-iw)/2:y=(oh-ih)/2")
+            videoFilters.add("${filterSettings.padFilter}=aspect=${it.stringValue()}:x=(ow-iw)/2:y=(oh-ih)/2")
         }
         filters?.let { videoFilters.addAll(it) }
         if (debugOverlay) {

--- a/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
+++ b/encore-common/src/main/kotlin/se/svt/oss/encore/service/FfmpegExecutor.kt
@@ -49,6 +49,7 @@ class FfmpegExecutor(
             it.getOutput(
                 encoreJob,
                 encoreProperties.encoding,
+                profile.filterSettings,
             )
         }
         check(outputs.isNotEmpty()) {

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/AudioEncodeTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/AudioEncodeTest.kt
@@ -30,7 +30,7 @@ class AudioEncodeTest {
     @Test
     fun `no audio streams throws exception`() {
         assertThatThrownBy {
-            audioEncode.getOutput(job(), EncodingProperties())
+            audioEncode.getOutput(job(), EncodingProperties(), FilterSettings())
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("No audio streams in input")
     }
@@ -42,6 +42,7 @@ class AudioEncodeTest {
             audioEncode.getOutput(
                 job,
                 EncodingProperties(audioMixPresets = mapOf("default" to AudioMixPreset(fallbackToAuto = false))),
+                FilterSettings(),
             )
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessage("Audio layout of audio input 'main' is not supported!")
@@ -52,6 +53,7 @@ class AudioEncodeTest {
         val output = audioEncode.getOutput(
             job(getAudioStream(6)),
             EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output)
             .hasOutput("test_aac_stereo.mp4")
@@ -69,7 +71,7 @@ class AudioEncodeTest {
     @Test
     fun `returns null when not enabled`() {
         val output = audioEncode.copy(enabled = false)
-            .getOutput(job(getAudioStream(6)), EncodingProperties())
+            .getOutput(job(getAudioStream(6)), EncodingProperties(), FilterSettings())
         assertThat(output).isNull()
     }
 
@@ -95,6 +97,7 @@ class AudioEncodeTest {
                     ),
                 ),
             ),
+            FilterSettings(),
         )
         assertThat(output)
             .hasOutput("test_aac_stereo.mp4")
@@ -137,6 +140,7 @@ class AudioEncodeTest {
                     ),
                 ),
             ),
+            FilterSettings(),
         )
         assertThat(output).isNull()
     }
@@ -157,6 +161,7 @@ class AudioEncodeTest {
                         ),
                     ),
                 ),
+                FilterSettings(),
             )
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("No audio mix preset for 'de': 5.1 -> stereo")
@@ -165,7 +170,7 @@ class AudioEncodeTest {
     @Test
     fun `unmapped input optional returns null`() {
         val audioEncodeLocal = audioEncode.copy(inputLabel = "other", optional = true)
-        val output = audioEncodeLocal.getOutput(job(getAudioStream(6)), EncodingProperties())
+        val output = audioEncodeLocal.getOutput(job(getAudioStream(6)), EncodingProperties(), FilterSettings())
         assertThat(output).isNull()
     }
 
@@ -173,7 +178,7 @@ class AudioEncodeTest {
     fun `unmapped input not optional throws`() {
         val audioEncodeLocal = audioEncode.copy(inputLabel = "other")
         assertThatThrownBy {
-            audioEncodeLocal.getOutput(job(getAudioStream(6)), EncodingProperties())
+            audioEncodeLocal.getOutput(job(getAudioStream(6)), EncodingProperties(), FilterSettings())
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessage("Can not generate test_aac_stereo.mp4! No audio input with label 'other'.")
     }

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncodeTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/ThumbnailEncodeTest.kt
@@ -27,6 +27,7 @@ class ThumbnailEncodeTest {
         val output = encode.getOutput(
             job = defaultEncoreJob(),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output)
             .hasOutput("test_thumb%02d.jpg")
@@ -46,6 +47,7 @@ class ThumbnailEncodeTest {
         val output = encode.copy(enabled = false).getOutput(
             job = defaultEncoreJob(),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output).isNull()
     }
@@ -57,6 +59,7 @@ class ThumbnailEncodeTest {
                 thumbnailTime = 5.0,
             ),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output)
             .hasOutput("test_thumb%02d.jpg")
@@ -80,6 +83,7 @@ class ThumbnailEncodeTest {
         val output = selectorEncode.getOutput(
             job = defaultEncoreJob(),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
 
         assertThat(output)
@@ -103,6 +107,7 @@ class ThumbnailEncodeTest {
                 duration = 4.0,
             ),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output)
             .hasOutput("test_thumb%02d.jpg")
@@ -133,6 +138,7 @@ class ThumbnailEncodeTest {
                 ),
             ),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output)
             .hasOutput("test_thumb%02d.jpg")
@@ -152,6 +158,7 @@ class ThumbnailEncodeTest {
         val output = encode.copy(inputLabel = "other", optional = true).getOutput(
             job = defaultEncoreJob(),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output).isNull()
     }
@@ -162,6 +169,7 @@ class ThumbnailEncodeTest {
             encode.copy(inputLabel = "other", optional = false).getOutput(
                 job = defaultEncoreJob(),
                 encodingProperties = EncodingProperties(),
+                FilterSettings(),
             )
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("No video input with label other!")

--- a/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncodeTest.kt
+++ b/encore-common/src/test/kotlin/se/svt/oss/encore/model/profile/ThumbnailMapEncodeTest.kt
@@ -23,7 +23,7 @@ class ThumbnailMapEncodeTest {
 
     @Test
     fun `correct output`() {
-        val output = encode.getOutput(defaultEncoreJob(), EncodingProperties())
+        val output = encode.getOutput(defaultEncoreJob(), EncodingProperties(), FilterSettings())
         assertThat(output)
             .hasNoAudioStreams()
             .hasId("_12x20_160x90_thumbnail_map.jpg")
@@ -44,6 +44,7 @@ class ThumbnailMapEncodeTest {
                 defaultEncoreJob()
                     .copy(seekTo = 1.0, duration = 5.0),
                 EncodingProperties(),
+                FilterSettings(),
             )
         assertThat(output)
             .hasNoAudioStreams()
@@ -63,6 +64,7 @@ class ThumbnailMapEncodeTest {
         val output = encode.copy(inputLabel = "other", optional = true).getOutput(
             job = defaultEncoreJob(),
             encodingProperties = EncodingProperties(),
+            FilterSettings(),
         )
         assertThat(output).isNull()
     }
@@ -73,6 +75,7 @@ class ThumbnailMapEncodeTest {
             encode.copy(inputLabel = "other", optional = false).getOutput(
                 job = defaultEncoreJob(),
                 encodingProperties = EncodingProperties(),
+                FilterSettings(),
             )
         }.isInstanceOf(RuntimeException::class.java)
             .hasMessageContaining("No input with label other!")
@@ -83,6 +86,7 @@ class ThumbnailMapEncodeTest {
         val output = encode.copy(enabled = false).getOutput(
             job = defaultEncoreJob(),
             encodingProperties = EncodingProperties(),
+            filterSettings = FilterSettings(),
         )
         assertThat(output).isNull()
     }


### PR DESCRIPTION
When doing hardware encoding, it can be desirable to use hardware filters for split, scaling, cropping and padding. This commits add support for specifying replacements for the standard filters in a profile. It is required that the filter specified supports the parameters used by encore.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed or added. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This has been tested by manually running jobs with hw filters defined in filter settings.

## Checklist:

- [X ] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)

